### PR TITLE
Code Review - Remover API Key del código

### DIFF
--- a/imports/ui/ModalMenu.js
+++ b/imports/ui/ModalMenu.js
@@ -15,6 +15,8 @@ class ModalExample extends React.Component {
 
   componentDidMount(){
 
+    //Juan Vega: Para evitar la exposición del API Key e información sensible pudiste usar variables de entorno, de forma que 
+    //no quedaran tus credenciales en texto plano dentro del código.
     fetch('https://api.flickr.com/services/rest/?method=flickr.people.getPublicPhotos&api_key=b11db2a17a833d9b1ac4c504bef12f4e&user_id=160816622%40N05&format=json&nojsoncallback=1')
     .then(function(response){
       return response.json();


### PR DESCRIPTION
Con el fin de evitar que terceros utilicen tu API Key para hacer peticiones a Flickr, es buena idea definir variables de entorno que guarden está información sensible, de forma que no quede expuesta directamente en el código. Con ello, eliminas este hueco de seguridad y te proteges contra solicitudes maliciosas.